### PR TITLE
Changing config frag so it accepts multiple files

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,6 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/spf13/cobra v0.0.7
 	github.com/spf13/pflag v1.0.5 // indirect
-	github.com/stretchr/objx v0.2.0 // indirect
 	github.com/stretchr/testify v1.5.1
 	go.uber.org/zap v1.15.0
 	golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d

--- a/go.sum
+++ b/go.sum
@@ -35,8 +35,6 @@ github.com/golang/groupcache v0.0.0-20190129154638-5b532d6fd5ef/go.mod h1:cIg4er
 github.com/golang/mock v1.1.1/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
-github.com/golang/protobuf v1.3.2 h1:6nsPYzhq5kReh6QImI3k5qWzO4PEbvbIW2cwSfR/6xs=
-github.com/golang/protobuf v1.3.2/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.4.0-rc.1/go.mod h1:ceaxUfeHdC40wWswd/P6IGgMaK3YpKi5j83Wpe3EHw8=
 github.com/golang/protobuf v1.4.0-rc.1.0.20200221234624-67d41d38c208/go.mod h1:xKAWHe0F5eneWXFV3EuXVDTCmh+JuBKY0li0aMyXATA=
 github.com/golang/protobuf v1.4.0-rc.2/go.mod h1:LlEzMj4AhA7rCAGe4KMBDvJI+AwstrUpVNzEA03Pprs=
@@ -48,6 +46,7 @@ github.com/google/btree v1.0.0/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
+github.com/google/go-cmp v0.4.0 h1:xsAVV57WRhGj6kEIi8ReJzQlHHqcBYCElAvkovg3B/4=
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-github v17.0.0+incompatible h1:N0LgJ1j65A7kfXrZnUDaYCs/Sf4rEjNlfyDHW9dolSY=
 github.com/google/go-github v17.0.0+incompatible/go.mod h1:zLgOLi98H3fifZn+44m+umXrS52loVEgC2AApnigrVQ=
@@ -123,8 +122,6 @@ github.com/spf13/viper v1.4.0/go.mod h1:PTJ7Z/lr49W6bUbkmS1V3by4uWynFiR9p7+dSq/y
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1 h1:2vfRuCMp5sSVIDSqO8oNnWJq7mPa6KVP3iPIwFBuy8A=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
-github.com/stretchr/objx v0.2.0 h1:Hbg2NidpLE8veEBkEZTL3CvlkUIVzuU9jDplZO54c48=
-github.com/stretchr/objx v0.2.0/go.mod h1:qt09Ya8vawLte6SNmTgCsAVtYtaKzEcn8ATUoHMkEqE=
 github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1w=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
@@ -193,6 +190,7 @@ golang.org/x/tools v0.0.0-20191029041327-9cc4af7d6b2c/go.mod h1:b+2E5dAYhXwXZwtn
 golang.org/x/tools v0.0.0-20191029190741-b9c20aec41a5 h1:hKsoRgsbwY1NafxrwTs+k64bikrLBkAgPir1TNCj3Zs=
 golang.org/x/tools v0.0.0-20191029190741-b9c20aec41a5/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=
 google.golang.org/appengine v1.4.0 h1:/wp5JvzpHIxhs/dumFmF7BXTf3Z+dd4uXta4kVyO508=
@@ -205,6 +203,7 @@ google.golang.org/protobuf v0.0.0-20200221191635-4d8936d0db64/go.mod h1:kwYJMbMJ
 google.golang.org/protobuf v0.0.0-20200228230310-ab0ca4ff8a60/go.mod h1:cfTl7dwQJ+fmap5saPgwCLgHXTUD7jkjRqWcaiX5VyM=
 google.golang.org/protobuf v1.20.1-0.20200309200217-e05f789c0967/go.mod h1:A+miEFZTKqfCUM6K7xSMQL9OKL/b6hQv+e19PK+JZNE=
 google.golang.org/protobuf v1.21.0/go.mod h1:47Nbq4nVaFHyn7ilMalzfO3qCViNmqZ2kzikPIcrTAo=
+google.golang.org/protobuf v1.23.0 h1:4MY060fB1DLGMB/7MBTLnwQUY6+F09GEiz6SsrNqyzM=
 google.golang.org/protobuf v1.23.0/go.mod h1:EGpADcykh3NcUnDUJcl1+ZksZNG86OlYog2l/sGQquU=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
@@ -216,8 +215,6 @@ gopkg.in/yaml.v2 v2.0.0-20170812160011-eb3733d160e7/go.mod h1:JAlM8MvJe8wmxCU4Bl
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
-gopkg.in/yaml.v2 v2.2.8 h1:obN1ZagJSUGI0Ek/LBmuj4SNLPfIny3KsKFopxRdj10=
-gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.3.0 h1:clyUAQHOM3G0M3f5vQj7LuJrETvjVot3Z5el9nffUtU=
 gopkg.in/yaml.v2 v2.3.0/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/internal/presentation/cli/cmd/config/collect.go
+++ b/internal/presentation/cli/cmd/config/collect.go
@@ -1,0 +1,70 @@
+package config
+
+import (
+	"sort"
+	"time"
+)
+
+type CollectConfig struct {
+	Organization string
+	Repositories []string
+	// Users should contain the handles of the users
+	Users            []string
+	From             time.Time
+	To               time.Time
+	Delta            time.Duration
+	OutputFilePrefix string
+}
+
+func (c CollectConfig) Merge(other CollectConfig) CollectConfig {
+	if len(other.Organization) > 0 {
+		c.Organization = other.Organization
+	}
+
+	repositories := c.mergeRepositories(other)
+	c.Repositories = make([]string, 0, len(repositories))
+
+	for r := range repositories {
+		c.Repositories = append(c.Repositories, r)
+	}
+
+	users := c.mergeUsers(other)
+	c.Users = make([]string, 0, len(users))
+
+	for r := range users {
+		c.Users = append(c.Users, r)
+	}
+
+	sort.Strings(c.Repositories)
+	sort.Strings(c.Users)
+
+	return c
+}
+
+func (c CollectConfig) mergeUsers(other CollectConfig) map[string]interface{} {
+	users := make(map[string]interface{}, len(c.Users)+len(other.Users))
+
+	for _, r := range c.Users {
+		users[r] = nil
+	}
+
+	for _, r := range other.Users {
+		users[r] = nil
+	}
+
+	return users
+}
+
+func (c CollectConfig) mergeRepositories(other CollectConfig) map[string]interface{} {
+	repositories := make(map[string]interface{}, len(c.Repositories)+len(other.Repositories))
+
+	for _, r := range c.Repositories {
+		repositories[r] = nil
+	}
+
+	for _, r := range other.Repositories {
+		repositories[r] = nil
+	}
+
+	return repositories
+}

--- a/internal/presentation/cli/cmd/config/collect_test.go
+++ b/internal/presentation/cli/cmd/config/collect_test.go
@@ -1,0 +1,105 @@
+package config_test
+
+import (
+	"testing"
+
+	"github.com/stefanoj3/gitstats/internal/presentation/cli/cmd/config"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCollectConfig_Merge(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		scenario       string
+		configs        []config.CollectConfig
+		expectedResult config.CollectConfig
+	}{
+		{
+			scenario: "one empty one filled",
+			configs: []config.CollectConfig{
+				{},
+				{
+					Organization: "myorg",
+					Repositories: []string{"myrepo1", "myrepo2"},
+					Users:        []string{"user1", "user2"},
+				},
+			},
+			expectedResult: config.CollectConfig{
+				Organization: "myorg",
+				Repositories: []string{"myrepo1", "myrepo2"},
+				Users:        []string{"user1", "user2"},
+			},
+		},
+		{
+			scenario: "organization of the first is overridden by the second",
+			configs: []config.CollectConfig{
+				{
+					Organization: "myorg1",
+				},
+				{
+					Organization: "myorg2",
+					Repositories: []string{"myrepo1", "myrepo2"},
+					Users:        []string{"user1", "user2"},
+				},
+			},
+			expectedResult: config.CollectConfig{
+				Organization: "myorg2",
+				Repositories: []string{"myrepo1", "myrepo2"},
+				Users:        []string{"user1", "user2"},
+			},
+		},
+		{
+			scenario: "repositories and users are merged",
+			configs: []config.CollectConfig{
+				{
+					Repositories: []string{"myrepo1", "myrepo2"},
+					Users:        []string{"user1", "user2"},
+				},
+				{
+					Organization: "myorg1",
+					Repositories: []string{"myrepo3", "myrepo4"},
+					Users:        []string{"user3", "user4"},
+				},
+			},
+			expectedResult: config.CollectConfig{
+				Organization: "myorg1",
+				Repositories: []string{"myrepo1", "myrepo2", "myrepo3", "myrepo4"},
+				Users:        []string{"user1", "user2", "user3", "user4"},
+			},
+		},
+		{
+			scenario: "duplicated users and repos are removed",
+			configs: []config.CollectConfig{
+				{
+					Repositories: []string{"myrepo1", "myrepo2", "myrepo3"},
+					Users:        []string{"user1", "user2", "user3"},
+				},
+				{
+					Organization: "myorg1",
+					Repositories: []string{"myrepo3", "myrepo4"},
+					Users:        []string{"user3", "user4"},
+				},
+			},
+			expectedResult: config.CollectConfig{
+				Organization: "myorg1",
+				Repositories: []string{"myrepo1", "myrepo2", "myrepo3", "myrepo4"},
+				Users:        []string{"user1", "user2", "user3", "user4"},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc // Pinning ranged variable, more info: https://github.com/kyoh86/scopelint
+
+		t.Run(tc.scenario, func(t *testing.T) {
+			var result config.CollectConfig
+
+			for _, c := range tc.configs {
+				result = result.Merge(c)
+			}
+
+			assert.Equal(t, tc.expectedResult, result)
+		})
+	}
+}


### PR DESCRIPTION
It is now possible to specify multiple config files, for example:
```bash
gitstats collect -c organization.toml,repositories.toml,team1.toml
```

Addressing https://github.com/stefanoj3/gitstats/issues/9